### PR TITLE
feat(helm)!: upgrade docker-registry helm chart to version 3.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ locals {
     name = "registry-cache"
 
     helm_chart_name    = "docker-registry"
-    helm_chart_version = "2.2.3"
-    helm_repo_url      = "https://lablabs.github.io/docker-registry.helm"
+    helm_chart_version = "3.0.0"
+    helm_repo_url      = "ghcr.io/lablabs/docker-registry.helm"
   }
 
   addon_irsa = {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

* **BREAKING** Changed chart repo to use ghcr.io for the docker-registry.helm
* Updated chart version from 2.2.3 to 3.0.0